### PR TITLE
Update version of Xcode used on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   macOS:
     description: A template for building and testing liboqs-python on macOS
     macos:
-      xcode: "11.3.0"
+      xcode: "13.2.0"
     steps:
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run:


### PR DESCRIPTION
The version we are using will be deprecated on January 12, 2022.