### PR TITLE
install liboqs-python in docker image so version check can succeed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,9 @@ COPY --from=intermediate /opt/liboqs-python /opt/liboqs-python
 
 ENV PYTHONPATH=/opt/liboqs-python
 
+# Install liboqs-python
+RUN cd /opt/liboqs-python && python3 setup.py install
+
 # Enable a normal user 
 RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs 
 


### PR DESCRIPTION
Your call, @vsoftco, whether enabling correct operation of the docker image for 0.7.2 would warrant a re-release...