### PR TITLE
Trigger CI on a `repository_dispatch` event.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "**" ]
   pull_request:
     branches: [ "**" ]
+  repository_dispatch:
+    types: [ "**" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR allows the CI for liboqs-python to be started via a `repository_dispatch` event, triggered by the GitHub API. In this way, the project's CI can be automatically triggered by the CI of an upstream repository such as liboqs. This will be done with the `oqs-bot` machine user via a GitHub personal access token, which will be stored in a CircleCI environment variable.

For a proof-of-concept of the CircleCI / GitHub Actions integration, see the following, in which the `cicd-playground-upstream` repo triggers a GitHub Action pipeline in `cicd-playground-downstream` via a CircleCI pipeline and a personal access token.

- https://github.com/swilson4/cicd-playground-upstream
- https://github.com/swilson4/cicd-playground-downstream
- https://app.circleci.com/pipelines/github/SWilson4/cicd-playground-upstream

When code to make the GitHub API call is added in the liboqs CI, this will address https://github.com/open-quantum-safe/liboqs/issues/1499.