### PR TITLE
Remove support for NIST KAT RNG

### DIFF
--- a/examples/rand.py
+++ b/examples/rand.py
@@ -11,15 +11,6 @@ from oqs import oqs_version, oqs_python_version
 print("liboqs version:", oqs_version())
 print("liboqs-python version:", oqs_python_version())
 
-# set the entropy seed to some values
-entropy_seed = [0] * 48
-for i in range(0, 48):
-    entropy_seed[i] = i
-
-oqsrand.randombytes_nist_kat_init_256bit(bytes(entropy_seed))
-oqsrand.randombytes_switch_algorithm("NIST-KAT")
-print('{:17s}'.format("NIST-KAT:"), ' '.join('{:02X}'.format(x) for x in oqsrand.randombytes(32)))
-
 # we do not yet support OpenSSL under Windows
 if platform.system() != "Windows":
     oqsrand.randombytes_switch_algorithm("OpenSSL")

--- a/oqs/rand.py
+++ b/oqs/rand.py
@@ -27,27 +27,8 @@ def randombytes_switch_algorithm(alg_name):
     """
     Switches the core OQS_randombytes to use the specified algorithm. See <oqs/rand.h> liboqs headers for more details.
 
-    :param alg_name: algorithm name, possible values are "system", "NIST-KAT", "OpenSSL".
+    :param alg_name: algorithm name, possible values are "system" and "OpenSSL".
     """
     if oqs.native().OQS_randombytes_switch_algorithm(
             oqs.ct.create_string_buffer(alg_name.encode())) != oqs.OQS_SUCCESS:
         raise RuntimeError('Can not switch algorithm')
-
-
-def randombytes_nist_kat_init_256bit(entropy_input, personalization_string=None):
-    """
-    Initializes the NIST DRBG with the an entropy seed. The security parameter is 256 bits.
-
-    :param entropy_input: entropy input seed, must be exactly 48 bytes long.
-    :param personalization_string: optional personalization string, which, if present, must be at least 48 bytes long.
-    """
-    if len(entropy_input) != 48:
-        raise ValueError('The entropy source must be exactly 48 bytes long')
-
-    if personalization_string is not None:
-        if len(personalization_string) < 48:
-            raise ValueError('The personalization string must be either empty or at least 48 bytes long')
-        oqs.native().OQS_randombytes_nist_kat_init_256bit(oqs.ct.create_string_buffer(entropy_input),
-                                                   oqs.ct.create_string_buffer(personalization_string))
-
-    oqs.native().OQS_randombytes_nist_kat_init_256bit(oqs.ct.create_string_buffer(entropy_input), 0)


### PR DESCRIPTION
As of open-quantum-safe/liboqs#1667 (merged but yet-to-be released), the NIST KAT pseudorandom number generator is no longer part of the public `liboqs` API. This PR removes all references to it from `liboqs-python`.

This should fix the [recent build failures](https://github.com/open-quantum-safe/liboqs-python/actions/runs/7612329010) on workflows triggered from upstream merges.

@vsoftco please let me know if there's anything else that needs to be done with regard to updating versions etc.