### PR TITLE
Fix Python attributes

### DIFF
--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -246,15 +246,24 @@ class KeyEncapsulation(ct.Structure):
 
         self._kem = native().OQS_KEM_new(ct.create_string_buffer(alg_name.encode()))
 
+        self.method_name = self._kem.contents.method_name
+        self.alg_version = self._kem.contents.alg_version
+        self.claimed_nist_level = self._kem.contents.claimed_nist_level
+        self.ind_cca = self._kem.contents.ind_cca
+        self.length_public_key = self._kem.contents.length_public_key
+        self.length_secret_key = self._kem.contents.length_secret_key
+        self.length_ciphertext = self._kem.contents.length_ciphertext
+        self.length_shared_secret = self._kem.contents.length_shared_secret
+
         self.details = {
-            "name": self._kem.contents.method_name.decode(),
-            "version": self._kem.contents.alg_version.decode(),
-            "claimed_nist_level": int(self._kem.contents.claimed_nist_level),
-            "is_ind_cca": bool(self._kem.contents.ind_cca),
-            "length_public_key": int(self._kem.contents.length_public_key),
-            "length_secret_key": int(self._kem.contents.length_secret_key),
-            "length_ciphertext": int(self._kem.contents.length_ciphertext),
-            "length_shared_secret": int(self._kem.contents.length_shared_secret),
+            "name": self.method_name.decode(),
+            "version": self.alg_version.decode(),
+            "claimed_nist_level": int(self.claimed_nist_level),
+            "is_ind_cca": bool(self.ind_cca),
+            "length_public_key": int(self.length_public_key),
+            "length_secret_key": int(self.length_secret_key),
+            "length_ciphertext": int(self.length_ciphertext),
+            "length_shared_secret": int(self.length_shared_secret),
         }
 
         if secret_key:
@@ -412,15 +421,25 @@ class Signature(ct.Structure):
                 raise MechanismNotSupportedError(alg_name)
 
         self._sig = native().OQS_SIG_new(ct.create_string_buffer(alg_name.encode()))
+
+        self.method_name = self._sig.contents.method_name
+        self.alg_version = self._sig.contents.alg_version
+        self.claimed_nist_level = self._sig.contents.claimed_nist_level
+        self.euf_cma = self._sig.contents.euf_cma
+        self.sig_with_ctx_support = self._sig.contents.sig_with_ctx_support
+        self.length_public_key = self._sig.contents.length_public_key
+        self.length_secret_key = self._sig.contents.length_secret_key
+        self.length_signature = self._sig.contents.length_signature
+
         self.details = {
-            "name": self._sig.contents.method_name.decode(),
-            "version": self._sig.contents.alg_version.decode(),
-            "claimed_nist_level": int(self._sig.contents.claimed_nist_level),
-            "is_euf_cma": bool(self._sig.contents.euf_cma),
-            "sig_with_ctx_support": bool(self._sig.contents.sig_with_ctx_support),
-            "length_public_key": int(self._sig.contents.length_public_key),
-            "length_secret_key": int(self._sig.contents.length_secret_key),
-            "length_signature": int(self._sig.contents.length_signature),
+            "name": self.method_name.decode(),
+            "version": self.alg_version.decode(),
+            "claimed_nist_level": int(self.claimed_nist_level),
+            "is_euf_cma": bool(self.euf_cma),
+            "sig_with_ctx_support": bool(self.sig_with_ctx_support),
+            "length_public_key": int(self.length_public_key),
+            "length_secret_key": int(self.length_secret_key),
+            "length_signature": int(self.length_signature),
         }
 
         if secret_key:

--- a/tests/test_kem.py
+++ b/tests/test_kem.py
@@ -68,6 +68,25 @@ def test_not_enabled():
                 raise AssertionError(f"An unexpected exception was raised: {ex}")
 
 
+def test_python_attributes():
+    for alg_name in oqs.get_enabled_kem_mechanisms():
+        with oqs.KeyEncapsulation(alg_name) as kem:
+            if kem.method_name.decode() != alg_name:
+                raise AssertionError("Incorrect oqs.KeyEncapsulation.method_name")
+            if kem.alg_version is None:
+                raise AssertionError("Undefined oqs.KeyEncapsulation.alg_version")
+            if not 1 <= kem.claimed_nist_level <= 5:
+                raise AssertionError("Invalid oqs.KeyEncapsulation.claimed_nist_level")
+            if kem.length_public_key == 0:
+                raise AssertionError("Incorrect oqs.KeyEncapsulation.length_public_key")
+            if kem.length_secret_key == 0:
+                raise AssertionError("Incorrect oqs.KeyEncapsulation.length_secret_key")
+            if kem.length_ciphertext == 0:
+                raise AssertionError("Incorrect oqs.KeyEncapsulation.length_signature")
+            if kem.length_shared_secret == 0:
+                raise AssertionError("Incorrect oqs.KeyEncapsulation.length_shared_secret")
+
+
 if __name__ == "__main__":
     try:
         import nose2

--- a/tests/test_kem.py
+++ b/tests/test_kem.py
@@ -75,5 +75,5 @@ if __name__ == "__main__":
         nose2.main()
     except ImportError:
         raise RuntimeError(
-            "nose2 module not found. Please install it with 'pip install node2'."
+            "nose2 module not found. Please install it with 'pip install nose2'."
         )

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -122,5 +122,5 @@ if __name__ == "__main__":
         nose2.main()
     except ImportError:
         raise RuntimeError(
-            "nose2 module not found. Please install it with 'pip install node2'."
+            "nose2 module not found. Please install it with 'pip install nose2'."
         )

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -115,6 +115,23 @@ def test_not_enabled():
                 raise AssertionError(f"An unexpected exception was raised: {ex}")
 
 
+def test_python_attributes():
+    for alg_name in oqs.get_enabled_sig_mechanisms():
+        with oqs.Signature(alg_name) as sig:
+            if sig.method_name.decode() != alg_name:
+                raise AssertionError("Incorrect oqs.Signature.method_name")
+            if sig.alg_version is None:
+                raise AssertionError("Undefined oqs.Signature.alg_version")
+            if not 1 <= sig.claimed_nist_level <= 5:
+                raise AssertionError("Invalid oqs.Signature.claimed_nist_level")
+            if sig.length_public_key == 0:
+                raise AssertionError("Incorrect oqs.Signature.length_public_key")
+            if sig.length_secret_key == 0:
+                raise AssertionError("Incorrect oqs.Signature.length_secret_key")
+            if sig.length_signature == 0:
+                raise AssertionError("Incorrect oqs.Signature.length_signature")
+
+
 if __name__ == "__main__":
     try:
         import nose2


### PR DESCRIPTION
`ctypes.Structure.__init__()` initializes the attributes using the list `_fields_`. However, this happens before `native().OQS_SIG_new()` is called. As a result, many attributes are either `None` or `0`.

I propose we manually populate the attributes from `self._sig`, and then we use these values to construct the dict `self.details`.

I also add a small unit test to check that Python attributes work.

~~If you like this approach I can complete this PR by fixing `KeyEncapsulation` attributes as well.~~

Fixes: #102 