### PR TITLE
Fix 'No such file or directory' when ctu.find_library don't find anything

### DIFF
--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -87,11 +87,17 @@ def _load_shared_obj(
                 # os.environ["LD_LIBRARY_PATH"] += os.path.abspath(path)
 
     # Search typical locations
-    if found_lib := ctu.find_library(name):
-        paths.insert(0, Path(found_lib))
+    try:
+        if found_lib := ctu.find_library(name):
+            paths.insert(0, Path(found_lib))
+    except:
+        pass
 
-    if found_lib := ctu.find_library("lib" + name):
-        paths.insert(0, Path(found_lib))
+    try:
+        if found_lib := ctu.find_library("lib" + name):
+            paths.insert(0, Path(found_lib))
+    except:
+        pass
 
     for path in paths:
         if path:


### PR DESCRIPTION
Installed with instructions from repo:
```
git clone --depth=1 https://github.com/open-quantum-safe/liboqs-python
cd liboqs-python
pip install .
```
When I just tried import oqs like this: `import oqs` I got error:
```
Traceback (most recent call last):
  File "/home/user/quantum_safe.py", line 6, in <module>
    import oqs
...
  File "/home/user/.venv/lib/python3.11/site-packages/oqs/oqs.py", line 93, in _load_shared_obj
    if found_lib := ctu.find_library("lib" + name):
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/ctypes/util.py", line 341, in find_library
    _get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))
                ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/ctypes/util.py", line 147, in _findLib_gcc
    if not _is_elf(file):
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/ctypes/util.py", line 99, in _is_elf
    with open(filename, 'br') as thefile:
         ^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: b'libliboqs.a'
```

Fox fix I suggest just do try+except.
(Maybe get output error if you want, but don't stop further script execution)