### PR TITLE
Fix Faulthandler import error for RobotFramework (RF).

### DIFF
--- a/.github/workflows/python_detailed.yml
+++ b/.github/workflows/python_detailed.yml
@@ -16,6 +16,7 @@ env:
   LD_LIBRARY_PATH: /usr/local/lib
   WIN_LIBOQS_INSTALL_PATH: C:\liboqs
   VERSION: 0.14.0
+  PYOQS_ENABLE_FAULTHANDLER: "1"
 
 concurrency:
   group: test-python-detailed-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/python_simplified.yml
+++ b/.github/workflows/python_simplified.yml
@@ -15,6 +15,8 @@ concurrency:
   group: test-python-simplified-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  PYOQS_ENABLE_FAULTHANDLER: "1"
 
 jobs:
   build:

--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -17,9 +17,7 @@ import platform  # to learn the OS we're on
 import subprocess
 import tempfile  # to install liboqs on demand
 import time
-import faulthandler
-
-faulthandler.enable()
+import os
 
 try:
     import tomllib  # Python 3.11+
@@ -51,6 +49,18 @@ TStatefulSignature = TypeVar("TStatefulSignature", bound="StatefulSignature")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler(stdout))
+
+# To identify issues in native code, we enable faulthandler.
+# As an example, this will print a stack trace if a segfault occurs,
+# if the STFL key generation flag was not set when building liboqs.
+if os.environ.get("PYOQS_ENABLE_FAULTHANDLER", "0") == "1":
+    import faulthandler
+
+    faulthandler.enable()
+    logger.info("liboqs-python faulthandler is enabled")
+else:
+    logger.info("liboqs-python faulthandler is disabled")
+
 
 # Expected return value from native OQS functions
 OQS_SUCCESS: Final[int] = 0
@@ -111,9 +121,7 @@ def _load_shared_obj(
             elif platform.system() == "Windows":
                 # Try both oqs.dll and liboqs.dll in the install path
                 for dll_name in (name, f"lib{name}"):
-                    paths.append(
-                        path.absolute() / Path(dll_name).with_suffix(".dll")
-                    )
+                    paths.append(path.absolute() / Path(dll_name).with_suffix(".dll"))
             else:  # Linux/FreeBSD/UNIX
                 paths.append(path.absolute() / Path(f"lib{name}").with_suffix(".so"))
                 # https://stackoverflow.com/questions/856116/changing-ld-library-path-at-runtime-for-ctypes

--- a/oqs/serialize.py
+++ b/oqs/serialize.py
@@ -92,6 +92,7 @@ def deserialize_stateful_signature_key(
     public_key_bytes = one_asym_key["publicKey"].asOctets()
     return private_key_bytes, public_key_bytes
 
+
 def _may_generate_stfl_key(
     key_name: str, dir_name: str
 ) -> tuple[Optional[bytes], Optional[bytes]]:


### PR DESCRIPTION

Add optional `faulthandler` import via environment flag for debugging

### Description

- Adds environment flag `PYOQS_ENABLE_FAULTHANDLER` to control the optional import of the Python `faulthandler` module.  
- Prevents import errors during Robot Framework (RF) test execution when `faulthandler` is unavailable or unsupported.  
- Retains improved debugging capabilities for segmentation faults when the flag is enabled.  

### Motivation and Context

While running RF tests with the [cmp-test-suite](https://github.com/siemens/cmp-test-suite) using **liboqs-python**, an import error occurred for the `faulthandler` module.  
This module was originally added to improve debugging for segmentation faults caused by missing build-time flags ( when PQC stateful hash signature key generation support was not enabled in liboqs).  

To maintain this helpful debugging functionality without breaking test environments, an environment variable `PYOQS_ENABLE_FAULTHANDLER` was introduced.  
When set, it enables `faulthandler` explicitly; otherwise, the module is skipped gracefully.  


