### PR TITLE
Bump version to 0.16.0-dev

### DIFF
--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -170,6 +170,10 @@ def _install_liboqs(
     if oqs_version_to_install is None:
         pass
 
+    elif oqs_version_to_install.endswith("-dev"):
+        # Pre-release dev versions of liboqs-python track liboqs main
+        oqs_version_to_install = None
+
     elif "rc" in oqs_version_to_install:
         # removed the "-" from the version string
         tmp = oqs_version_to_install.split("rc")

--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -170,8 +170,9 @@ def _install_liboqs(
     if oqs_version_to_install is None:
         pass
 
-    elif oqs_version_to_install.endswith("-dev"):
-        # Pre-release dev versions of liboqs-python track liboqs main
+    elif "dev" in oqs_version_to_install:
+        # Pre-release dev versions of liboqs-python (e.g. 0.16.0.dev0,
+        # 0.16.0-dev) track liboqs main, since no matching tag exists.
         oqs_version_to_install = None
 
     elif "rc" in oqs_version_to_install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "liboqs-python"
 requires-python = ">=3.9"
-version = "0.14.0"
+version = "0.16.0-dev"
 description = "Python bindings for liboqs, providing post-quantum public key cryptography algorithms"
 authors = [
     { name = "Open Quantum Safe project", email = "contact@openquantumsafe.org" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version to `0.16.0-dev`. liboqs-python 0.13/0.14/0.15 were never released; jumping directly to 0.16.0 to realign with the upcoming liboqs 0.16.0.
- Teach `_install_liboqs` to treat any `-dev` suffix as "clone liboqs main" (no `--branch` flag), since no matching tag exists yet.

## Test plan
- [x] Fresh import on a machine without liboqs installed clones and builds liboqs `main`.
- [x] Existing liboqs install at 0.15.x is still detected and used; mismatch warning fires (expected — minor differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)