### PR TITLE
CI: only run push workflow on main (#124)

### DIFF
--- a/.github/workflows/python_detailed.yml
+++ b/.github/workflows/python_detailed.yml
@@ -2,7 +2,7 @@ name: GitHub actions detailed
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
   repository_dispatch:

--- a/.github/workflows/python_simplified.yml
+++ b/.github/workflows/python_simplified.yml
@@ -2,7 +2,7 @@ name: GitHub actions simplified
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
   repository_dispatch:


### PR DESCRIPTION
## Summary
- Both `push` and `pull_request` triggered on `"**"`, so PRs from same-repo branches ran every workflow twice.
- Restrict `push` to `main`; `pull_request` still covers PRs from any branch.

Closes #124.

## Test plan
- [x] Verify this PR itself runs each workflow only once.
- [ ] After merge, confirm push to `main` still triggers workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)