### PR TITLE
Add PYOQS_VERSION env var to override auto-installed liboqs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ of the process.
 This is convenient in case you want to avoid installing liboqs manually, as
 described in the subsection above.
 
+By default, liboqs-python installs the liboqs release that matches its own
+version. Set the `PYOQS_VERSION` environment variable to override this:
+
+```shell
+export PYOQS_VERSION=0.15.0   # install a specific liboqs release
+export PYOQS_VERSION=latest   # install liboqs from main (HEAD)
+```
+
 ### Install and activate a Python virtual environment
 
 Execute in a Terminal/Console/Administrator Command Prompt

--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -91,8 +91,16 @@ def oqs_python_version() -> Union[str, None]:
 
 
 # liboqs-python tries to automatically install and load this liboqs version in
-# case no other version is found
-OQS_VERSION = oqs_python_version()
+# case no other version is found. The default tracks liboqs-python's own
+# version; set the PYOQS_VERSION environment variable to override (use
+# "latest" to pull liboqs HEAD).
+_pyoqs_version_override = os.environ.get("PYOQS_VERSION")
+if _pyoqs_version_override is None:
+    OQS_VERSION = oqs_python_version()
+elif _pyoqs_version_override == "latest":
+    OQS_VERSION = None
+else:
+    OQS_VERSION = _pyoqs_version_override
 
 
 def version(version_str: str) -> tuple[str, str, str]:


### PR DESCRIPTION
By default liboqs-python auto-installs the liboqs release matching its own version. Setting PYOQS_VERSION overrides that target:

  PYOQS_VERSION=0.15.0   # install a specific liboqs release
  PYOQS_VERSION=latest   # install liboqs from main (HEAD)

The override applies only at the install site (OQS_VERSION). The oqs_python_version() helper is unchanged, so the liboqs vs. liboqs-python version-mismatch warning continues to report the actually-installed package version rather than the override.

Closes #132, #133.