### PR TITLE
Fix StatefulSignature.export_secret_key TypeErrors on Windows

### DIFF
--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -1153,7 +1153,7 @@ class StatefulSignature(ct.Structure):
             msg = "Secret‑key serialization failed"
             raise ValueError(msg)
         data = ct.string_at(buf_ptr, buf_len.value)
-        ct.CDLL(ct.util.find_library("c")).free(buf_ptr)
+        native().OQS_MEM_secure_free(buf_ptr, buf_len.value)
         return data
 
     def sigs_total(self) -> int:
@@ -1204,7 +1204,19 @@ class StatefulSignature(ct.Structure):
 
 
 native().OQS_SIG_STFL_new.restype = ct.POINTER(StatefulSignature)
-native().OQS_SIG_STFL_SECRET_KEY_new.restype = ct.c_void_p
+
+
+# Subclass c_void_p so the returned pointer stays as a ctypes object rather
+# than being auto-unwrapped to a Python int. On 64-bit Windows Python 3.14,
+# a pointer with the high bit set round-tripping through a Python int into
+# a c_void_p argument triggers "OverflowError: int too long to convert".
+# Keeping it as a ctypes object uses the same-type fast path on the way back
+# in and avoids the int conversion entirely. (Issue #136.)
+class _OQS_SIG_STFL_SECRET_KEY_p(ct.c_void_p):
+    pass
+
+
+native().OQS_SIG_STFL_SECRET_KEY_new.restype = _OQS_SIG_STFL_SECRET_KEY_p
 native().OQS_SIG_STFL_SECRET_KEY_new.argtypes = [ct.c_char_p]
 # Added precise signatures for (de)serialization to avoid ABI issues
 native().OQS_SIG_STFL_SECRET_KEY_serialize.restype = ct.c_int
@@ -1213,6 +1225,8 @@ native().OQS_SIG_STFL_SECRET_KEY_serialize.argtypes = [
     ct.POINTER(ct.c_size_t),
     ct.c_void_p,
 ]
+native().OQS_MEM_secure_free.restype = None
+native().OQS_MEM_secure_free.argtypes = [ct.c_void_p, ct.c_size_t]
 native().OQS_SIG_STFL_SECRET_KEY_deserialize.restype = ct.c_int
 native().OQS_SIG_STFL_SECRET_KEY_deserialize.argtypes = [
     ct.c_void_p,


### PR DESCRIPTION
Two failures reported in #136, both in export_secret_key:

1. On Python 3.14 32-bit: ct.util.find_library("c") returns None on Windows, so CDLL(None) raises TypeError. Even on Unix where it worked, liboqs's malloc and libc's free can come from different CRT heaps on Windows. Use liboqs's own OQS_MEM_secure_free instead — ABI-compatible by construction, and also zeroizes the secret-key bytes before freeing.

2. On Python 3.14 64-bit: OQS_SIG_STFL_SECRET_KEY_serialize fails with "OverflowError: int too long to convert" on argument 3 (the secret-key handle). Cause: restype c_void_p auto-unwraps the returned pointer to a Python int, and on Windows Python 3.14 the int -> c_void_p arg conversion path chokes on high-bit-set addresses. Use a c_void_p subclass as the restype so ctypes keeps the pointer as an object; subsequent calls take the same-type fast path and skip int conversion entirely.

Closes #136.