### PR TITLE
Update Python versions to 3.12-3.14

### DIFF
--- a/.github/workflows/python_detailed.yml
+++ b/.github/workflows/python_detailed.yml
@@ -17,6 +17,7 @@ env:
   WIN_LIBOQS_INSTALL_PATH: C:\liboqs
   VERSION: 0.14.0
   PYOQS_ENABLE_FAULTHANDLER: "1"
+  UV_PYTHON: "3.14"
 
 concurrency:
   group: test-python-detailed-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -39,8 +40,8 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
 
-      - name: Set up Python 3.9
-        run: uv python install 3.9
+      - name: Set up Python 3.14
+        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/python_simplified.yml
+++ b/.github/workflows/python_simplified.yml
@@ -22,8 +22,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+    runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,8 +37,8 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
 
-      - name: Set up Python 3.9
-        run: uv python install 3.9
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Run examples
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liboqs-python"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 version = "0.16.0-dev"
 description = "Python bindings for liboqs, providing post-quantum public key cryptography algorithms"
 authors = [
@@ -41,7 +41,7 @@ homepage = "https://github.com/open-quantum-safe/liboqs-python"
 repository = "https://github.com/open-quantum-safe/liboqs-python.git"
 
 [tool.isort]
-py_version = 39
+py_version = 310
 src_paths = ["oqs"]
 line_length = 99
 multi_line_output = 3
@@ -56,7 +56,7 @@ extend_skip_glob = []
 
 [tool.ruff]
 src = ["oqs"]
-target-version = "py39"
+target-version = "py310"
 line-length = 99
 exclude = [
     ".git",
@@ -96,7 +96,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 mypy_path = "."
 packages = ["oqs"]
 plugins = []


### PR DESCRIPTION
CI and the project configuration currently target Python 3.9, which is now end-of-life.

This commit updates the project configuration to use version 3.10 and higher, and does CI testing on versions 3.10-3.14. It does simplified tests on Ubuntu for all supported Python versions (3.10-3.14), plus detailed CI on all supported platforms (Ubuntu, macOS, Windows) on 3.14.

Fixes #96.