### PR TITLE
Bump version to 0.16.1-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "liboqs-python"
 requires-python = ">=3.10"
-version = "0.16.0"
+version = "0.16.1-dev"
 description = "Python bindings for liboqs, providing post-quantum public key cryptography algorithms"
 authors = [
     { name = "Open Quantum Safe project", email = "contact@openquantumsafe.org" },


### PR DESCRIPTION
Opens the next development cycle now that 0.16.0 is tagged and released.

Only `pyproject.toml` changes: `0.16.0` -> `0.16.1-dev`.

- The runtime auto-installer already treats any version containing `dev` as "clone liboqs main" (`oqs/oqs.py`), so the tree tracks liboqs HEAD rather than looking for a nonexistent `0.16.1` tag. PEP 440 normalizes `0.16.1-dev` to `0.16.1.dev0` at install time; the `"dev" in ...` check catches both spellings.
- CI's `VERSION` in `.github/workflows/python_detailed.yml` stays at `0.16.0`, the last released liboqs, since there is no liboqs `0.16.1` tag to build against yet. This matches the previous cycle, where the tree was `0.16.0-dev` while CI built against liboqs `0.14.0`.
- `CHANGES.md` and `RELEASE.md` are untouched; they document the released 0.16.0 and get rewritten at release-prep time.

This mirrors the previous dev bump, #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)