### PR TITLE
Skip extmu ML-DSA variants in generic signature tests

### DIFF
--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -4,8 +4,13 @@ import random
 import oqs
 from oqs.oqs import Signature, native
 
-# Sigs for which unit testing is disabled
-disabled_sig_patterns = []
+# Sigs for which unit testing is disabled.
+#
+# The ML-DSA "external mu" (extmu) variants require an externally computed mu
+# and cannot be signed via the standard sign() API, so exclude them from the
+# generic sign/verify correctness tests. See
+# https://github.com/open-quantum-safe/liboqs-python/issues/151.
+disabled_sig_patterns = ["extmu"]
 
 if platform.system() == "Windows":
     disabled_sig_patterns = [""]


### PR DESCRIPTION
## Problem

The "GitHub actions simplified" CI workflow is failing on `main` (and therefore on every open PR) in the unit-test step:

```
'ML-DSA-44-extmu' ... ERROR
'ML-DSA-65-extmu' ... ERROR
'ML-DSA-87-extmu' ... ERROR
ERROR: tests.test_sig.test_correctness:4
RuntimeError: Can not sign message
```

Because the package version is a `dev` version (`0.16.1-dev`), the CI builds liboqs from `main` HEAD, which now enables the external-mu ML-DSA variants (`ML-DSA-{44,65,87}-extmu`). These cannot be signed via the standard `OQS_SIG_sign` path — they expect an externally-computed µ rather than a raw message. The generic correctness tests in `tests/test_sig.py` iterate over **all** enabled mechanisms and call plain `sig.sign(message)`, so they fail for these variants.

## Fix

Add `"extmu"` to `disabled_sig_patterns` in `tests/test_sig.py` so the generic sign/verify correctness tests skip the external-mu variants.

This is a stopgap to unblock CI failures as identified in #150. Proper support — a dedicated external-mu signing path in the `Signature` wrapper plus tests that actually exercise these algorithms — is tracked in #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)