### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/python_detailed.yml
+++ b/.github/workflows/python_detailed.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/python_simplified.yml
+++ b/.github/workflows/python_simplified.yml
@@ -28,10 +28,10 @@ jobs:
       UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
           enable-cache: true


### PR DESCRIPTION
Update actions/checkout v4 -> v7.0.1 and
astral-sh/setup-uv v5 -> v9.0.0, pinning both to
full commit SHAs with a version comment.