### PR TITLE
Add external-mu (extmu) support to Signature wrapper and tests

### DIFF
--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -657,6 +657,10 @@ class Signature(ct.Structure):
         self.claimed_nist_level = self._sig.contents.claimed_nist_level
         self.euf_cma = self._sig.contents.euf_cma
         self.sig_with_ctx_support = bool(self._sig.contents.sig_with_ctx_support)
+        # External-mu ("extmu") variants (e.g. ML-DSA-*-extmu) reuse the standard
+        # sign/verify API but interpret the message input as the externally
+        # computed mu rather than a raw message.
+        self.is_extmu = "-extmu" in self.method_name.decode()
         self.length_public_key = self._sig.contents.length_public_key
         self.length_secret_key = self._sig.contents.length_secret_key
         self.length_signature = self._sig.contents.length_signature
@@ -669,6 +673,7 @@ class Signature(ct.Structure):
             "is_suf_cma": bool(self.suf_cma),
             "supports_context_signing": bool(self.sig_with_ctx_support),
             "sig_with_ctx_support": bool(self.sig_with_ctx_support),
+            "is_extmu": self.is_extmu,
             "length_public_key": int(self.length_public_key),
             "length_secret_key": int(self.length_secret_key),
             "length_signature": int(self.length_signature),
@@ -719,7 +724,12 @@ class Signature(ct.Structure):
         """
         Signs the provided message and returns the signature.
 
-        :param message: the message to sign.
+        For external-mu variants (is_extmu, e.g. ML-DSA-*-extmu), message is the
+        externally computed mu rather than a raw message; liboqs enforces its
+        length (64 bytes for ML-DSA).
+
+        :param message: the message to sign (the externally computed mu for
+        external-mu variants).
         """
         # Provide length to avoid extra null char
         c_message = ct.create_string_buffer(message, len(message))
@@ -746,7 +756,11 @@ class Signature(ct.Structure):
         """
         Verify the provided signature on the message; returns True if valid.
 
-        :param message: the signed message.
+        For external-mu variants (is_extmu, e.g. ML-DSA-*-extmu), message is the
+        externally computed mu rather than a raw message.
+
+        :param message: the signed message (the externally computed mu for
+        external-mu variants).
         :param signature: the signature on the message.
         :param public_key: the signer's public key.
         """

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -4,16 +4,20 @@ import random
 import oqs
 from oqs.oqs import Signature, native
 
-# Sigs for which unit testing is disabled.
-#
-# The ML-DSA "external mu" (extmu) variants require an externally computed mu
-# and cannot be signed via the standard sign() API, so exclude them from the
-# generic sign/verify correctness tests. See
-# https://github.com/open-quantum-safe/liboqs-python/issues/151.
-disabled_sig_patterns = ["extmu"]
+# Sigs for which unit testing is disabled
+disabled_sig_patterns = []
 
 if platform.system() == "Windows":
     disabled_sig_patterns = [""]
+
+# External-mu (extmu) variants interpret the signed input as the externally
+# computed mu rather than a raw message. For ML-DSA that mu is 64 bytes (FIPS
+# 204); liboqs's own test suite likewise hardcodes this length for extmu.
+EXTMU_MESSAGE_LEN = 64
+
+
+def _message_len(alg_name: str) -> int:
+    return EXTMU_MESSAGE_LEN if "-extmu" in alg_name else 100
 
 
 def test_correctness() -> tuple[None, str]:
@@ -34,7 +38,7 @@ def test_correctness_with_ctx_str() -> tuple[None, str]:
 
 def check_correctness(alg_name: str) -> None:
     with oqs.Signature(alg_name) as sig:
-        message = bytes(random.getrandbits(8) for _ in range(100))
+        message = bytes(random.getrandbits(8) for _ in range(_message_len(alg_name)))
         public_key = sig.generate_keypair()
         signature = sig.sign(message)
         assert sig.verify(message, signature, public_key)  # noqa: S101
@@ -47,6 +51,15 @@ def check_correctness_with_ctx_str(alg_name: str) -> None:
         public_key = sig.generate_keypair()
         signature = sig.sign_with_ctx_str(message, context)
         assert sig.verify_with_ctx_str(message, signature, context, public_key)  # noqa: S101
+
+
+def test_is_extmu_flag() -> None:
+    """The is_extmu flag is exposed consistently and set for external-mu variants."""
+    for alg_name in oqs.get_enabled_sig_mechanisms():
+        with oqs.Signature(alg_name) as sig:
+            expected = "-extmu" in alg_name
+            assert sig.is_extmu == expected  # noqa: S101
+            assert sig.details["is_extmu"] == expected  # noqa: S101
 
 
 def test_sig_with_ctx_support_detection() -> None:
@@ -83,7 +96,7 @@ def test_wrong_message() -> tuple[None, str]:
 
 def check_wrong_message(alg_name: str) -> None:
     with oqs.Signature(alg_name) as sig:
-        message = bytes(random.getrandbits(8) for _ in range(100))
+        message = bytes(random.getrandbits(8) for _ in range(_message_len(alg_name)))
         public_key = sig.generate_keypair()
         signature = sig.sign(message)
         wrong_message = bytes(random.getrandbits(8) for _ in range(len(message)))
@@ -99,7 +112,7 @@ def test_wrong_signature() -> tuple[None, str]:
 
 def check_wrong_signature(alg_name: str) -> None:
     with oqs.Signature(alg_name) as sig:
-        message = bytes(random.getrandbits(8) for _ in range(100))
+        message = bytes(random.getrandbits(8) for _ in range(_message_len(alg_name)))
         public_key = sig.generate_keypair()
         signature = sig.sign(message)
         wrong_signature = bytes(random.getrandbits(8) for _ in range(len(signature)))
@@ -115,7 +128,7 @@ def test_wrong_public_key() -> tuple[None, str]:
 
 def check_wrong_public_key(alg_name: str) -> None:
     with oqs.Signature(alg_name) as sig:
-        message = bytes(random.getrandbits(8) for _ in range(100))
+        message = bytes(random.getrandbits(8) for _ in range(_message_len(alg_name)))
         public_key = sig.generate_keypair()
         signature = sig.sign(message)
         wrong_public_key = bytes(random.getrandbits(8) for _ in range(len(public_key)))


### PR DESCRIPTION
Adds first-class support for the ML-DSA external-mu variants (`ML-DSA-44-extmu`, `ML-DSA-65-extmu`, `ML-DSA-87-extmu`) that liboqs now enables, replacing the temporary test skip from #152.

## Background

externalMu is the FIPS 204 (Algorithm 7) option to supply the message representative µ from a separate cryptographic module instead of a raw message. In liboqs this was added in [open-quantum-safe/liboqs#2366](https://github.com/open-quantum-safe/liboqs/pull/2366), following the design discussion in [open-quantum-safe/liboqs#2254](https://github.com/open-quantum-safe/liboqs/issues/2254).

## API design rationale

The liboqs design deliberately **reuses the existing sign/verify API** rather than introducing a dedicated function. From [#2254](https://github.com/open-quantum-safe/liboqs/issues/2254), the maintainer's chosen approach (Option 1) is to *"reuse the existing signing API and interpret the message input as `mu` for these variants"*, explicitly rejecting a new `OQS_SIG_sign_with_external_mu` because *"externalMu is algorithm-specific"* and *"adding a new global API is difficult to justify."* Accordingly:

- There is **no dedicated external-mu C function** to bind — `sign()`/`verify()` already work for extmu; the caller simply passes the externally computed µ as the "message".
- liboqs exposes **no runtime µ length** (it lives only in per-algorithm compile-time macros, e.g. `OQS_SIG_ml_dsa_44_extmu_length_mu = 64`) and enforces its own 64-byte check internally.

This PR mirrors that philosophy in the Python wrapper — keeping the signing API uniform and algorithm-agnostic instead of re-encoding a per-algorithm crypto constant:

- Add an **`is_extmu`** flag (instance attribute + `details`) so callers can detect external-mu variants.
- Document on `sign()`/`verify()` that for extmu variants the input is the externally computed µ.
- No new methods and no hardcoded µ length in `oqs.py` — length validation is left to liboqs.

## Tests

- Parametrize the generic sign/verify tests to use a 64-byte message for extmu variants, mirroring liboqs's own [`tests/test_sig.c`](https://github.com/open-quantum-safe/liboqs/blob/main/tests/test_sig.c) (which likewise hardcodes 64 in test code). This restores full correctness / wrong-message / wrong-signature / wrong-public-key coverage for the extmu variants.
- Drop the `"extmu"` entry from `disabled_sig_patterns` (the #152 stopgap).
- Add `test_is_extmu_flag`.

Verified locally against a liboqs build with the extmu variants enabled.

Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)